### PR TITLE
Feature/orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="android.intent.action.CONFIGURATION_CHANGED" />
             </intent-filter>
 
             <meta-data
@@ -43,5 +44,4 @@
             android:name=".ui.service.ArticleListWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
     </application>
-
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-                <action android:name="android.intent.action.CONFIGURATION_CHANGED" />
             </intent-filter>
 
             <meta-data

--- a/app/src/main/java/com/itj/sandersonwidget/ProgressBarsConfigureActivity.kt
+++ b/app/src/main/java/com/itj/sandersonwidget/ProgressBarsConfigureActivity.kt
@@ -47,10 +47,11 @@ class ProgressBarsConfigureActivity : Activity() {
         setResult(RESULT_OK, resultValue)
         finish()
     }
+
     // Todo make matching nicer than hardcoded and error prone Strings
     private var onThemeSpinnerItemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-            val chosenTheme = when(parent?.getItemAtPosition(position)) {
+            val chosenTheme = when (parent?.getItemAtPosition(position)) {
                 "Way of Kings" -> R.style.Theme_SandersonWidget_AppWidgetContainer_WayOfKings
                 "Words of Radiance" -> R.style.Theme_SandersonWidget_AppWidgetContainer_WordsOfRadiance
                 "Oathbringer" -> R.style.Theme_SandersonWidget_AppWidgetContainer_Oathbringer

--- a/app/src/main/java/com/itj/sandersonwidget/ProgressBarsWidgetProvider.kt
+++ b/app/src/main/java/com/itj/sandersonwidget/ProgressBarsWidgetProvider.kt
@@ -24,9 +24,6 @@ import java.util.concurrent.TimeUnit
  * Implementation of App Widget functionality.
  * App Widget Configuration implemented in [ProgressBarsConfigureActivity]
  */
-// TODO after late lunch/next time: you're trying to receive broadcasts of orientation change events but
-// your hungry brain can't work out why AWP can't receive broadcasts like a regular receiver. Get that working and the
-// background should update on rotation!
 class ProgressBarsWidgetProvider : AppWidgetProvider() {
 
     companion object {
@@ -36,7 +33,7 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
         private const val INVALID_WIDGET_DIMENSION = -1
     }
 
-    private val widgetViewMap: MutableMap<Int, Pair<RemoteViews, RemoteViews>> = mutableMapOf()
+//    private val widgetViewMap: MutableMap<Int, Pair<RemoteViews, RemoteViews>> = mutableMapOf()
     private var appWidgetManager: AppWidgetManager? = null
 
     override fun onUpdate(
@@ -58,12 +55,12 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
         // todo this is broken and removing data before it can be used
 //            SharedPreferencesStorage(context).clearAll()
 //        }
-        for (appWidgetId in appWidgetIds) {
-            widgetViewMap.remove(appWidgetId)
-        }
-        if (widgetViewMap.isEmpty()) {
-            appWidgetManager = null
-        }
+//        for (appWidgetId in appWidgetIds) {
+//            widgetViewMap.remove(appWidgetId)
+//        }
+//        if (widgetViewMap.isEmpty()) {
+//            appWidgetManager = null
+//        }
     }
 
     override fun onEnabled(context: Context) {
@@ -86,7 +83,13 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
     override fun onReceive(context: Context?, intent: Intent?) {
         when (intent?.action) {
             ACTION_ARTICLE_CLICK -> handleArticleClick(context, intent)
-            ACTION_CONFIGURATION_CHANGED -> handleConfigurationChange(context)
+            /**
+             * We can't monitor this intent action from AppWidgetProvider, and introducing a regular Broadcast Receiver
+             * is not advised. It's suggested that Launcher applications should be responsible for triggering
+             * configuration changes in widget:
+             * https://stackoverflow.com/questions/2435548/how-to-detect-orientation-change-in-home-screen-widget#:~:text=Since%20Android%20API%2016%2C%20there,min%2Fmax%20width%2Fheight.&text=When%20this%20is%20called%2C%20one,have%20to%20get%20orientation%20information.
+             */
+//            ACTION_CONFIGURATION_CHANGED -> handleConfigurationChange(context)
         }
 
         super.onReceive(context, intent)
@@ -109,7 +112,7 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
             if (minWidth != INVALID_WIDGET_DIMENSION) {
                 val portraitLayout = LayoutProvider().fetchLayout(context, appWidgetId, gridSize, minWidth, maxHeight)
                 val landscapeLayout = LayoutProvider().fetchLayout(context, appWidgetId, gridSize, maxWidth, minHeight)
-                widgetViewMap[appWidgetId] = Pair(portraitLayout, landscapeLayout)
+//                widgetViewMap[appWidgetId] = Pair(portraitLayout, landscapeLayout)
 
                 val orientation = context.resources.configuration.orientation
                 if (orientation == ORIENTATION_PORTRAIT) {
@@ -136,22 +139,22 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
         }
     }
 
-    private fun handleConfigurationChange(context: Context?) {
-        context?.let {
-            val orientation = it.resources.configuration.orientation
-            appWidgetManager?.let { appWidgetManager ->
-                for (appWidgetId in widgetViewMap.keys) {
-                    if (orientation == ORIENTATION_PORTRAIT) {
-                        widgetViewMap[appWidgetId]?.first
-                    } else {
-                        widgetViewMap[appWidgetId]?.second
-                    }?.let { views ->
-                        updateAppWidget(appWidgetManager, appWidgetId, views)
-                    }
-                }
-            }
-        }
-    }
+//    private fun handleConfigurationChange(context: Context?) {
+//        context?.let {
+//            val orientation = it.resources.configuration.orientation
+//            appWidgetManager?.let { appWidgetManager ->
+//                for (appWidgetId in widgetViewMap.keys) {
+//                    if (orientation == ORIENTATION_PORTRAIT) {
+//                        widgetViewMap[appWidgetId]?.first
+//                    } else {
+//                        widgetViewMap[appWidgetId]?.second
+//                    }?.let { views ->
+//                        updateAppWidget(appWidgetManager, appWidgetId, views)
+//                    }
+//                }
+//            }
+//        }
+//    }
 }
 
 internal fun updateAppWidget(

--- a/app/src/main/java/com/itj/sandersonwidget/ProgressBarsWidgetProvider.kt
+++ b/app/src/main/java/com/itj/sandersonwidget/ProgressBarsWidgetProvider.kt
@@ -33,7 +33,6 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
         private const val INVALID_WIDGET_DIMENSION = -1
     }
 
-//    private val widgetViewMap: MutableMap<Int, Pair<RemoteViews, RemoteViews>> = mutableMapOf()
     private var appWidgetManager: AppWidgetManager? = null
 
     override fun onUpdate(
@@ -54,12 +53,6 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
 //        for (appWidgetId in appWidgetIds) {
         // todo this is broken and removing data before it can be used
 //            SharedPreferencesStorage(context).clearAll()
-//        }
-//        for (appWidgetId in appWidgetIds) {
-//            widgetViewMap.remove(appWidgetId)
-//        }
-//        if (widgetViewMap.isEmpty()) {
-//            appWidgetManager = null
 //        }
     }
 
@@ -83,13 +76,6 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
     override fun onReceive(context: Context?, intent: Intent?) {
         when (intent?.action) {
             ACTION_ARTICLE_CLICK -> handleArticleClick(context, intent)
-            /**
-             * We can't monitor this intent action from AppWidgetProvider, and introducing a regular Broadcast Receiver
-             * is not advised. It's suggested that Launcher applications should be responsible for triggering
-             * configuration changes in widget:
-             * https://stackoverflow.com/questions/2435548/how-to-detect-orientation-change-in-home-screen-widget#:~:text=Since%20Android%20API%2016%2C%20there,min%2Fmax%20width%2Fheight.&text=When%20this%20is%20called%2C%20one,have%20to%20get%20orientation%20information.
-             */
-//            ACTION_CONFIGURATION_CHANGED -> handleConfigurationChange(context)
         }
 
         super.onReceive(context, intent)
@@ -112,7 +98,6 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
             if (minWidth != INVALID_WIDGET_DIMENSION) {
                 val portraitLayout = LayoutProvider().fetchLayout(context, appWidgetId, gridSize, minWidth, maxHeight)
                 val landscapeLayout = LayoutProvider().fetchLayout(context, appWidgetId, gridSize, maxWidth, minHeight)
-//                widgetViewMap[appWidgetId] = Pair(portraitLayout, landscapeLayout)
 
                 val orientation = context.resources.configuration.orientation
                 if (orientation == ORIENTATION_PORTRAIT) {
@@ -138,23 +123,6 @@ class ProgressBarsWidgetProvider : AppWidgetProvider() {
             }
         }
     }
-
-//    private fun handleConfigurationChange(context: Context?) {
-//        context?.let {
-//            val orientation = it.resources.configuration.orientation
-//            appWidgetManager?.let { appWidgetManager ->
-//                for (appWidgetId in widgetViewMap.keys) {
-//                    if (orientation == ORIENTATION_PORTRAIT) {
-//                        widgetViewMap[appWidgetId]?.first
-//                    } else {
-//                        widgetViewMap[appWidgetId]?.second
-//                    }?.let { views ->
-//                        updateAppWidget(appWidgetManager, appWidgetId, views)
-//                    }
-//                }
-//            }
-//        }
-//    }
 }
 
 internal fun updateAppWidget(

--- a/app/src/main/java/com/itj/sandersonwidget/ui/helper/WidgetSizingHelper.kt
+++ b/app/src/main/java/com/itj/sandersonwidget/ui/helper/WidgetSizingHelper.kt
@@ -2,34 +2,7 @@ package com.itj.sandersonwidget.ui.helper
 
 /**
  * https://developer.android.com/guide/topics/appwidgets/layouts
-Number of cells (width x height)	Available size in portrait mode (dp)	Available size in landscape mode (dp)
-1x1	57x102dp	127x51dp
-2x1	130x102dp	269x51dp
-3x1	203x102dp	412x51dp
-4x1	276x102dp	554x51dp
-5x1	349x102dp	697x51dp
-5x2	349x220dp	697x117dp
-5x3	349x337dp	697x184dp
-5x4	349x455dp	697x250dp
-...	...	...
-n x m	(73n - 16) x (118m - 16)	(142n - 15) x (66m - 15)
  */
-/**
- * 1080x1794 - 2.625
- * Grid for pixel2 starting at 2x2:
- *  Cells          2           3           4           5
- *  Width:      144-206     225-317     305-428     385-540
- *  Height:     134-176     209-273     284-369     359-465
- */
-/**
- * 1080x2148 - 2.75
- * Grid for pixel4 starting at 2x2:
- *  Cells        2          3           4           5
- *  Width:      130-249     203-382     276-514     349-647
- *  Height:     134-209     193-322     263-434     X
- */
-// 134-209  193-273     263-369
-
 // width: 2 is small, 3-4 is medium, 5+ is large
 // height: 1 is small, 2 is medium, 3+ is large
 internal sealed class DimensionSize {

--- a/app/src/main/java/com/itj/sandersonwidget/ui/layouts/LayoutProvider.kt
+++ b/app/src/main/java/com/itj/sandersonwidget/ui/layouts/LayoutProvider.kt
@@ -20,19 +20,6 @@ import com.itj.sandersonwidget.ui.service.ProgressItemWidgetService
 import com.itj.sandersonwidget.ui.service.ProgressItemWidgetService.Companion.NUMBER_OF_ITEMS
 import com.itj.sandersonwidget.ui.view.getCustomProgressBarBitMap
 
-// todo for api>=31
-//    val smallView = RemoteViews(context.packageName, R.layout.view_small)
-//    val mediumView = RemoteViews(context.packageName, R.layout.view_medium)
-//    val largeView = RemoteViews(context.packageName, R.layout.view_large)
-//
-//    val viewMapping: Map<SizeF, RemoteViews> = mapOf(
-//        SizeF(150f, 100f) to smallView,
-//        SizeF(150f, 200f) to mediumView,
-//        SizeF(215f, 100f) to largeView,
-//    )
-//
-//    val remoteViews = RemoteViews(viewMapping)
-//    appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
 /**
  * https://developer.android.com/guide/topics/appwidgets/layouts
  */


### PR DESCRIPTION
- Now checking orientation when 'onAppWidgetOptionsChanged' is called.
- Unfortunately there's no way to trigger based on orientation changes, but if something is discovered there's some code in 9684d33457c2a93757e9b98e98917b134a76f547 for reacting and updating the widget.